### PR TITLE
コピペ用の「月」が正しく返らないのを修正

### DIFF
--- a/app/javascript/copy_paste.ts
+++ b/app/javascript/copy_paste.ts
@@ -66,7 +66,7 @@ class CopyPaste {
 
     return [
       selectedDate.getFullYear(),
-      selectedDate.getMonth(),
+      selectedDate.getMonth() + 1, // 1月は「0」が返ってくる
       selectedDate.getDate(),
       dayOfWeek[selectedDate.getDay()]
     ]


### PR DESCRIPTION
# 概要

`Date.prototype.getMonth()` が想定と違う挙動をしていたのに気づいたので修正。

詳細は下記

## 想定と実際

「年・月・日」の「月」を `getMonth()` で取得

### 想定

「1月の場合」→ `1` が返る

### 実際

「1月の場合」 → `0` が返る

※「n 月」の場合、必ず「n - 1」で返ってくる

# Link

* [Date.prototype.getMonth() - JavaScript | MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth)